### PR TITLE
Changed from using numpy dot and numpy inverse methods in train_LM function to scipy alternatives.

### DIFF
--- a/python/pyrenn.py
+++ b/python/pyrenn.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy
 
 def CreateNN(nn,dIn=[0],dIntern=[],dOut=[]):
 	"""Create Neural Network
@@ -696,7 +697,7 @@ def train_LM(P,Y,net,k_max=100,E_stop=1e-10,dampfac=3.0,dampconst=10.0,\
 	while True:
 	#run loop until either k_max or E_stop is reached
 
-		JJ = np.dot(J.transpose(),J) #J.transp * J
+		JJ = scipy.linalg.blas.dgemm(alpha=1.0,a=J.T,b=J.T,trans_b=True)#J.transp * J
 		w = net['w'] #weight vector
 		
 		while True:
@@ -707,7 +708,7 @@ def train_LM(P,Y,net,k_max=100,E_stop=1e-10,dampfac=3.0,dampconst=10.0,\
 			
 			#calculate scaled inverse hessian
 			try:
-				G = np.linalg.inv(JJ+dampfac*np.eye(net['N'])) #scaled inverse hessian
+				G = scipy.linalg.inv(JJ+dampfac*np.eye(net['N'])) #scaled inverse hessian
 			except numpy.linalg.LinAlgError:
 				# Not invertible. Go small step in gradient direction
 				w_delta = 1.0/1e10 * g

--- a/python/pyrenn.py
+++ b/python/pyrenn.py
@@ -387,6 +387,9 @@ def RTRL(net,data):
 	CsX = {}		#CsX[u]: Set of input layers x with an existing sensitivity matrix
 					#S[q,u,x]
 					#Cs and CsX are generated during the Backpropagation
+					
+	max_delay  = network['max_delay'] # Maximum delay used for updating the dA_dw dict
+    max_layers = len(layers) # Maximum number of layers used for updating the dA_dw dict
 			
 	#Initialize
 	J = np.zeros((Q0*layers[-1],net['N']))	#Jacobian matrix
@@ -492,6 +495,15 @@ def RTRL(net,data):
 			
 		# Jacobian Matrix
 		J[range(((q-q0)-1)*outputs,(q-q0)*outputs),:] = -dA_dw[q,M]
+		
+		# Update both dA_dw and S dictionary after each cycle
+		if q > max_delay:
+            new_dA_dw = {}
+            for dd in range(max_delay):
+                for ll in xrange(1, max_layers+1):
+                    new_dA_dw[(q-dd,ll)] = dA_dw[(q-dd,ll)]
+            dA_dw = new_dA_dw
+            S = {}
 		
 	return J,E,e
 


### PR DESCRIPTION
The first change I found useful was switching from using the
numpy.dot method to the scipy alternative called
scipy.linalg.blas.dgemm method. The reason for this change is
under the hood when you call numpy.dot, it copies the array's due
to its need to have them in C-contiguous order, but when you
switch to the scipy alternative, it doesn't copy the arrays as you
pass them in as C-contiguous. This change both prevents the excess
memory consumption of the copy, and also the performance bottleneck
due to it. This change helps mostly when it comes to very large
datasets such as the ones i'm using and the result is significantly
faster using the scipy version.

The second possible change I found useful was switching from the
numpy inverse method to its scipy alternative. The reason for this
is scipy always is compiled with BLAS/LAPACK support while for
numpy it is only optional. I found utilizing this change resulted
in this calculation taking 1/6th the amount of time roughly when
using very large datasets.

Feel free to test these changes and let me know if you like them.
Also thank you for providing this code as it has helped me on a
personal project of mine.
